### PR TITLE
Add codex test using fixture sessions

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,4 @@
 import { pathToFileURL } from 'node:url'
-import React from 'react'
 import { render } from 'ink'
 import { getSessions } from './codex'
 import { resumeSession } from './resume'

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import type { ChildProcess, SpawnOptionsWithoutStdio } from 'node:child_process'
+import type { ChildProcess, SpawnOptions } from 'node:child_process'
 
 export interface ResumeSessionOptions {
   binary?: string
@@ -10,7 +10,7 @@ export interface ResumeSessionOptions {
   spawnImpl?: (
     command: string,
     args: ReadonlyArray<string>,
-    options: SpawnOptionsWithoutStdio,
+    options: SpawnOptions,
   ) => ChildProcess
   forwardSignals?: NodeJS.Signals[]
 }
@@ -50,7 +50,7 @@ export async function resumeSession(
     ...extraArgs,
   ]
 
-  const spawnOptions: SpawnOptionsWithoutStdio = {
+  const spawnOptions: SpawnOptions = {
     stdio: 'inherit',
     env,
   }

--- a/tests/codex.test.ts
+++ b/tests/codex.test.ts
@@ -1,0 +1,79 @@
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+import { getSessions } from '../src/codex'
+import { LiteLLMPricingFetcher } from '../src/pricing'
+
+const fixtureHome = fileURLToPath(new URL('./fixtures/codex-home', import.meta.url))
+
+test('getSessions reads fixture sessions and marks forks with pricing data', async () => {
+  const pricingFetcher = new LiteLLMPricingFetcher({
+    offline: true,
+    offlineLoader: async () => ({
+      'gpt-5-codex': {
+        input_cost_per_token: 1e-6,
+        output_cost_per_token: 2e-6,
+        cache_read_input_token_cost: 5e-7,
+      },
+      'gpt-4.1-mini': {
+        input_cost_per_token: 2e-6,
+        output_cost_per_token: 3e-6,
+      },
+    }),
+  })
+
+  const { sessions, totalBlendedTokens, totalCostUsd } = await getSessions({
+    codexHome: fixtureHome,
+    pricingFetcher,
+  })
+
+  expect(sessions).toHaveLength(2)
+
+  const [newer, older] = sessions
+
+  expect(newer.id).toBe('22222222-2222-4222-8222-222222222222')
+  expect(newer.branchMarker).toBe('┌')
+  expect(newer.isFork).toBe(true)
+  expect(newer.preview).toBe('Build me a web app')
+  expect(newer.forkSignature).toBe('Build me a web app')
+  expect(newer.model).toBe('gpt-4.1-mini')
+  expect(newer.tokenUsage).toEqual({
+    inputTokens: 1000,
+    cachedInputTokens: 0,
+    outputTokens: 900,
+    reasoningOutputTokens: 100,
+    totalTokens: 2000,
+  })
+  expect(newer.modelUsage.get('gpt-4.1-mini')).toEqual({
+    inputTokens: 1000,
+    cachedInputTokens: 0,
+    outputTokens: 900,
+    reasoningOutputTokens: 100,
+    totalTokens: 2000,
+  })
+  expect(newer.costUsd).toBeCloseTo(0.0047)
+
+  expect(older.id).toBe('11111111-1111-4111-8111-111111111111')
+  expect(older.branchMarker).toBe('┴')
+  expect(older.isFork).toBe(false)
+  expect(older.meta?.instructions).toBeNull()
+  expect(older.meta?.originator).toBe('tester')
+  expect(older.model).toBe('gpt-5-codex')
+  expect(older.tokenUsage).toEqual({
+    inputTokens: 600,
+    cachedInputTokens: 100,
+    outputTokens: 400,
+    reasoningOutputTokens: 0,
+    totalTokens: 1000,
+  })
+  expect(older.modelUsage.get('gpt-5-codex')).toEqual({
+    inputTokens: 600,
+    cachedInputTokens: 100,
+    outputTokens: 400,
+    reasoningOutputTokens: 0,
+    totalTokens: 1000,
+  })
+  expect(older.costUsd).toBeCloseTo(0.00135)
+
+  expect(totalBlendedTokens).toBe(2900)
+  expect(totalCostUsd).toBeCloseTo(0.00605)
+})

--- a/tests/fixtures/codex-home/sessions/2024/12/25/rollout-2024-12-25T15-30-00-11111111-1111-4111-8111-111111111111.jsonl
+++ b/tests/fixtures/codex-home/sessions/2024/12/25/rollout-2024-12-25T15-30-00-11111111-1111-4111-8111-111111111111.jsonl
@@ -1,0 +1,5 @@
+{"timestamp":"2024-12-25T15-30-00","type":"session_meta","payload":{"id":"11111111-1111-4111-8111-111111111111","timestamp":"2024-12-25T15-30-00","instructions":null,"cwd":"/work","originator":"tester","cli_version":"1.0.0"}}
+{"timestamp":"2024-12-25T15-30-05","type":"event_msg","payload":{"type":"user_message","message":"Build me a web app","kind":"plain"}}
+{"timestamp":"2024-12-25T15-30-10","type":"turn_context","payload":{"model":"gpt-5-codex"}}
+{"timestamp":"2024-12-25T15-31-00","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":600,"cached_input_tokens":100,"output_tokens":400,"reasoning_output_tokens":0,"total_tokens":1000}}}}
+{"record_type":"response","index":0}

--- a/tests/fixtures/codex-home/sessions/2024/12/26/rollout-2024-12-26T10-15-00-22222222-2222-4222-8222-222222222222.jsonl
+++ b/tests/fixtures/codex-home/sessions/2024/12/26/rollout-2024-12-26T10-15-00-22222222-2222-4222-8222-222222222222.jsonl
@@ -1,0 +1,5 @@
+{"timestamp":"2024-12-26T10-15-00","type":"session_meta","payload":{"id":"22222222-2222-4222-8222-222222222222","timestamp":"2024-12-26T10-15-00","instructions":"Follow best practices","cwd":"/work","originator":"tester","cli_version":"1.0.0"}}
+{"timestamp":"2024-12-26T10-15-04","type":"event_msg","payload":{"type":"user_message","message":"Build me a web app","kind":"plain"}}
+{"timestamp":"2024-12-26T10-15-08","type":"turn_context","payload":{"model":"gpt-4.1-mini"}}
+{"timestamp":"2024-12-26T10-15-10","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":0,"output_tokens":900,"reasoning_output_tokens":100,"total_tokens":2000}}}}
+{"record_type":"response","index":0}


### PR DESCRIPTION
## Summary
- add a codex Vitest spec that loads sessions from a fixture home directory
- provide rollout JSON fixtures to exercise fork detection, token accounting, and pricing
- fix TypeScript errors by updating codex helpers, removing unused React imports, and adjusting resume spawn options

## Testing
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d8200101b883338b31bb647b29b846